### PR TITLE
[FIXED] Disabled recycler view focus on load issue reported in #10.

### DIFF
--- a/app/src/main/res/layout/fragment_recycler_view_with_fix.xml
+++ b/app/src/main/res/layout/fragment_recycler_view_with_fix.xml
@@ -33,7 +33,8 @@
 
         <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:descendantFocusability="blocksDescendants">
             <!-- DEV NOTE: Outer wrapper relative layout is added intentionally to address issue
                  that only happens on Marshmallow & Nougat devices (API 23 & 24).
 

--- a/app/src/main/res/layout/fragment_recycler_view_with_nested_scrollview_fix.xml
+++ b/app/src/main/res/layout/fragment_recycler_view_with_nested_scrollview_fix.xml
@@ -11,7 +11,8 @@ Solution based on answer: http://stackoverflow.com/a/37338715/132121
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:descendantFocusability="blocksDescendants">
 
         <TextView
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_recycler_view_without_fix.xml
+++ b/app/src/main/res/layout/fragment_recycler_view_without_fix.xml
@@ -8,7 +8,8 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:descendantFocusability="blocksDescendants">
 
         <TextView
             android:layout_width="match_parent"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha6'
+        classpath 'com.android.tools.build:gradle:2.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Solution was taken from http://stackoverflow.com/questions/34329707/nestedscrollview-scrolls-to-top-on-recyclerview-resized

This fixes https://github.com/amardeshbd/android-recycler-view-wrap-content/issues/10
